### PR TITLE
Discord Rich Presence Integration

### DIFF
--- a/ElDorito/Source/Blam/BlamNetwork.cpp
+++ b/ElDorito/Source/Blam/BlamNetwork.cpp
@@ -3,6 +3,7 @@
 
 #include "BlamNetwork.hpp"
 #include "../Pointer.hpp"
+#include "../Discord/DiscordRPC.h"
 
 namespace
 {
@@ -183,9 +184,9 @@ namespace Blam::Network
 		return GetGameVariant(this);
 	}
 
-	void* MapVariantSessionParameter::Get() const
+	MapVariant* MapVariantSessionParameter::Get() const
 	{
-		typedef void*(__thiscall *GetMapVariantPtr)(const MapVariantSessionParameter *thisPtr);
+		typedef MapVariant*(__thiscall *GetMapVariantPtr)(const MapVariantSessionParameter *thisPtr);
 		auto GetMapVariant = reinterpret_cast<GetMapVariantPtr>(0x456410);
 		return GetMapVariant(this);
 	}
@@ -250,7 +251,12 @@ namespace Blam::Network
 	bool SetNetworkMode(int mode)
 	{
 		auto Set_Network_Mode = (bool(__cdecl*)(int))(0x00A7F950);
-		return Set_Network_Mode(mode);
+		bool success = Set_Network_Mode(mode);
+
+		//Let Discord Know
+		Discord::DiscordRPC::Instance().UpdatePresence();
+
+		return success;
 	}
 	
 	bool Disconnect()

--- a/ElDorito/Source/Blam/BlamNetwork.hpp
+++ b/ElDorito/Source/Blam/BlamNetwork.hpp
@@ -144,7 +144,7 @@ namespace Blam::Network
 		uint8_t Unknown1[0x2A0B4];
 
 		// Gets the current variant data, or null if not available.
-		void* Get() const;
+		MapVariant* Get() const;
 	};
 	static_assert(sizeof(MapVariantSessionParameter) == 0x2A1D0, "Invalid c_network_session_parameter_map_variant size");
 

--- a/ElDorito/Source/Discord/DiscordRPC.cpp
+++ b/ElDorito/Source/Discord/DiscordRPC.cpp
@@ -1,11 +1,15 @@
 #include "DiscordRPC.h"
 
-#include <string.h>
 #include <time.h>
 
+#include "../Blam/BlamEvents.hpp"
 #include "../Blam/BlamNetwork.hpp"
+#include "../Blam/BlamPlayers.hpp"
+#include "../Blam/BlamTypes.hpp"
 #include "../Patches/Core.hpp"
+#include "../Patches/Events.hpp"
 #include "../Patches/Network.hpp"
+#include "../Modules/ModuleServer.hpp"
 #include "../Web/Ui/ScreenLayer.hpp"
 #include "../ThirdParty/rapidjson/stringbuffer.h"
 #include "../ThirdParty/rapidjson/writer.h"
@@ -15,31 +19,10 @@
 
 #include "../Utils/Logger.hpp"
 
+static const char* APPLICATION_ID = "378984448022020112";
+
 namespace
 {
-	void handleDiscordReady()
-	{
-		memset(&Discord::DiscordRPC::Instance().discordPresence, 0, sizeof(Discord::DiscordRPC::Instance().discordPresence));
-		Discord::DiscordRPC::Instance().discordPresence.state = "ElDewrito";
-		Discord::DiscordRPC::Instance().discordPresence.startTimestamp = time(0);
-		Discord::DiscordRPC::Instance().discordPresence.endTimestamp = time(0);
-		Discord::DiscordRPC::Instance().discordPresence.largeImageKey = "unknown";
-		Discord::DiscordRPC::Instance().discordPresence.smallImageKey = "unk-small";
-		Discord::DiscordRPC::Instance().discordPresence.partyId = "party1234";
-		Discord::DiscordRPC::Instance().discordPresence.joinSecret = ""; //TODO: cache/generate this after joining or hosting a session
-		Discord::DiscordRPC::Instance().discordPresence.spectateSecret = "";
-		Discord::DiscordRPC::Instance().discordPresence.matchSecret = "";
-		Discord::DiscordRPC::Instance().discordPresence.partySize = 1;
-		Discord::DiscordRPC::Instance().discordPresence.partyMax = 16;
-		Discord::DiscordRPC::Instance().discordPresence.instance = 1;
-		Discord_UpdatePresence(&Discord::DiscordRPC::Instance().discordPresence);
-	}
-
-	void LifeCycle(Blam::Network::LifeCycleState state)
-	{
-		handleDiscordReady();
-	}
-
 	void handleDiscordDisconnected(int errorCode, const char *message)
 	{
 		Utils::Logger::Instance().Log(Utils::LogTypes::Game, Utils::LogLevel::Error, "Discord-RPC: %s", std::string(message));
@@ -64,7 +47,7 @@ namespace
 	{
 		rapidjson::StringBuffer jsonBuffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(jsonBuffer);
-		
+
 		writer.StartObject();
 		writer.Key("userId");
 		writer.String(joinRequest->userId);
@@ -76,10 +59,93 @@ namespace
 
 		Web::Ui::ScreenLayer::Notify("discord-joinrequest", jsonBuffer.GetString(), true);
 	}
+
+	void PresenceUpdate()
+	{
+		auto get_multiplayer_scoreboard = (Blam::MutiplayerScoreboard*(*)())(0x00550B80);
+		Discord::DiscordRPC::Instance().detailString.clear();
+		memset(&Discord::DiscordRPC::Instance().discordPresence, 0, sizeof(Discord::DiscordRPC::discordPresence));
+
+		auto* session = Blam::Network::GetActiveSession();
+		if (session && session->IsEstablished())
+		{
+			if (strcmp((char*)Pointer(0x22AB018)(0x1A4), "mainmenu") == 0)
+			{
+				Discord::DiscordRPC::Instance().discordPresence.largeImageKey = "default";
+				Discord::DiscordRPC::Instance().discordPresence.largeImageText = "Mainmenu";
+				Discord::DiscordRPC::Instance().discordPresence.details = "In an Online Lobby";
+			}
+			else
+			{
+				Discord::DiscordRPC::Instance().discordPresence.largeImageKey = (char*)Pointer(0x22AB018)(0x1A4);
+				Discord::DiscordRPC::Instance().discordPresence.largeImageText = (char*)Pointer(0x22AB018)(0x1A4);
+				auto game = session->Parameters.GameVariant.Get();
+				auto map = session->Parameters.MapVariant.Get();
+
+				if (game && map)
+				{
+					std::stringstream ss;
+					ss << Utils::String::ThinString(game->Name) << " on " << Utils::String::ThinString(map->ContentHeader.Name);
+					Discord::DiscordRPC::Instance().detailString = ss.str(); //Need a variable that will stay active
+					Discord::DiscordRPC::Instance().discordPresence.details = Discord::DiscordRPC::Instance().detailString.c_str();
+					Discord::DiscordRPC::Instance().discordPresence.smallImageKey = Blam::GameTypeNames[game->GameType].c_str();
+					Discord::DiscordRPC::Instance().discordPresence.smallImageText = Blam::GameTypeNames[game->GameType].c_str();
+				}
+			}
+			int players = 0;
+			int plyIndex = session->MembershipInfo.FindFirstPlayer();
+			while (plyIndex != -1)
+			{
+				players++;
+				plyIndex = session->MembershipInfo.FindNextPlayer(plyIndex);
+			}
+
+			Discord::DiscordRPC::Instance().discordPresence.partySize = players;
+			Discord::DiscordRPC::Instance().discordPresence.partyMax = session->MembershipInfo.SessionMaxPlayers;
+			Discord::DiscordRPC::Instance().discordPresence.state = Modules::ModuleServer::Instance().VarServerNameClient->ValueString.c_str();
+		}
+		else
+		{
+			Discord::DiscordRPC::Instance().discordPresence.state = "At the Mainmenu";
+			Discord::DiscordRPC::Instance().discordPresence.largeImageKey = "default";
+			Discord::DiscordRPC::Instance().discordPresence.largeImageText = (char*)Pointer(0x22AB018)(0x1A4);
+			Discord::DiscordRPC::Instance().discordPresence.details = "Alone";
+			Discord::DiscordRPC::Instance().discordPresence.partySize = 1;
+			Discord::DiscordRPC::Instance().discordPresence.partyMax = 1;
+		}
+
+		Discord_UpdatePresence(&Discord::DiscordRPC::Instance().discordPresence);
+	}
+
+	void handleDiscordReady()
+	{
+		PresenceUpdate();
+	}
+
+	void MapLoaded(const char* mappath)
+	{
+		PresenceUpdate();
+	}
+
+	void Event(Blam::DatumIndex player, const Blam::Events::Event *event, const Blam::Events::EventDefinition *definition)
+	{
+		PresenceUpdate();
+	}
+
+	void Lifecycle(Blam::Network::LifeCycleState newState)
+	{
+		PresenceUpdate();
+	}
 }
 
 namespace Discord
 {
+
+	void DiscordRPC::UpdatePresence()
+	{
+		PresenceUpdate();
+	}
+
 	DiscordRPC::DiscordRPC()
 	{
 		DiscordEventHandlers handlers;
@@ -90,15 +156,13 @@ namespace Discord
 		handlers.joinGame = handleDiscordJoin;
 		handlers.spectateGame = handleDiscordSpectate;
 		handlers.joinRequest = handleDiscordJoinRequest;
-		Discord_Initialize("378984448022020112", &handlers, 1, NULL);
+		Discord_Initialize(APPLICATION_ID, &handlers, 1, NULL);
 
 		Patches::Core::OnShutdown(Discord_Shutdown);
-		Patches::Network::OnLifeCycleStateChanged(LifeCycle);
-	}
-
-	void DiscordRPC::UpdatePresence()
-	{
-		Discord_UpdatePresence(&Discord::DiscordRPC::Instance().discordPresence);
+		Patches::Core::OnGameStart(PresenceUpdate);
+		Patches::Core::OnMapLoaded(MapLoaded);
+		Patches::Events::OnEvent(Event);
+		Patches::Network::OnLifeCycleStateChanged(Lifecycle);
 	}
 
 	void DiscordRPC::ReplyToJoinRequest(const char* userId, int reply)

--- a/ElDorito/Source/Discord/DiscordRPC.h
+++ b/ElDorito/Source/Discord/DiscordRPC.h
@@ -1,12 +1,13 @@
 #include <discord-rpc.h>
 #include "../Utils/Singleton.hpp"
-
+#include <string>
 namespace Discord
 {
 	class DiscordRPC : public Utils::Singleton<DiscordRPC>
 	{
 	public:
 		DiscordRichPresence discordPresence;
+		std::string detailString;
 
 		void Update();
 		void UpdatePresence();

--- a/ElDorito/Source/ElDorito.cpp
+++ b/ElDorito/Source/ElDorito.cpp
@@ -296,6 +296,8 @@ std::string ElDorito::GetDirectory()
 	return Dir;
 }
 
+bool firstShow = true;
+
 void ElDorito::OnMainMenuShown()
 {
 	if (GameHasMenuShown)


### PR DESCRIPTION
* Began Discord Module
* Discord Rich Presence tests successfully.
* Module now reports gametype, map, and server name, with image key
* Now automatically updates presence on map load, game start, and game stop
* Rewrote Update Presence + hooks to check gamemode/lobbytype & Network mode.
 (Map Variant name not working.)
* Undid a pointless change
* Final version pre-merge maybe
* Multi-team gametype icons. Actual last commit before conforming to upstream
* Conformed to upstream
* Removed outdated files.
* Made requested changes
* Did some refactors, removed a loop and the memset. Took some advice.
* Fixed max player count
* MaximumGame's Lean version. Goodbye score i will see you again someday.
* I will not forget a semicolon
* included <string>